### PR TITLE
fix: 그림판 터치이벤트 #346

### DIFF
--- a/src/data/routes/urls.ts
+++ b/src/data/routes/urls.ts
@@ -31,4 +31,4 @@ export const NAVER_AUTH_URL = `https://nid.naver.com/oauth2.0/authorize?response
 
 const GOOGLE_CLIENT_ID = process.env.REACT_APP_GOOGLE_CLIENT_ID;
 const GOOGLE_REDIRECT_URI = process.env.REACT_APP_GOOGLE_REDIRECT_URI;
-export const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile`;
+export const GOOGLE_AUTH_URL = `https://accounts.google.com/o/oauth2/v2/auth?client_id=${GOOGLE_CLIENT_ID}&redirect_uri=${GOOGLE_REDIRECT_URI}&response_type=code&scope=email%20profile&access_type=offline`;

--- a/src/features/post/hooks/useEraser.ts
+++ b/src/features/post/hooks/useEraser.ts
@@ -3,12 +3,12 @@ import { Coordinate } from "../../../data/type/type";
 
 export const useEraser = (
   ref: React.RefObject<HTMLCanvasElement>,
-  action: Function
+  action: (event: MouseEvent) => Coordinate | undefined,
+  mouse: Coordinate | undefined,
+  setMouse: React.Dispatch<React.SetStateAction<Coordinate | undefined>>
 ) => {
   const [isErasing, setIsErasing] = useState<boolean>(false);
-  const [mousePosition, setMousePosition] = useState<Coordinate | undefined>(
-    undefined
-  );
+
   // canvas에 선긋는 함수
   const eraseLine = (originalMousePosition: Coordinate) => {
     if (ref.current) {
@@ -29,39 +29,33 @@ export const useEraser = (
     }
   };
 
-  const startErase = useCallback(
-    (event: React.MouseEvent<HTMLCanvasElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const coordinates = action(event);
-      if (coordinates) {
-        setIsErasing(true);
-        setMousePosition(coordinates);
-      }
-    },
-    []
-  );
+  const startErase = useCallback((event: MouseEvent) => {
+    const coordinates = action(event);
+    if (coordinates) {
+      setIsErasing(true);
+      setMouse(coordinates);
+    }
+  }, []);
 
   const erase = useCallback(
-    (event: React.MouseEvent<HTMLCanvasElement>) => {
+    (event: MouseEvent) => {
       event.preventDefault();
       event.stopPropagation();
 
       if (isErasing) {
         const newMousePosition = action(event);
-        if (mousePosition && newMousePosition) {
-          eraseLine(mousePosition);
-          setMousePosition(newMousePosition);
+        if (mouse && newMousePosition) {
+          eraseLine(mouse);
+          setMouse(newMousePosition);
         }
       }
     },
-    [isErasing, mousePosition]
+    [isErasing, mouse]
   );
 
   const exitErase = useCallback(() => {
-    // setIsPainting(false);
     setIsErasing(false);
   }, []);
 
-  return { startErase, erase, exitErase };
+  return { startErase, erase, exitErase, isErasing };
 };

--- a/src/features/post/hooks/usePen.ts
+++ b/src/features/post/hooks/usePen.ts
@@ -3,14 +3,13 @@ import { Coordinate } from "../../../data/type/type";
 
 export const usePen = (
   ref: React.RefObject<HTMLCanvasElement>,
-  action: Function,
+  action: (event: MouseEvent) => Coordinate | undefined,
   color: string,
-  penSize: number
+  penSize: number,
+  mouse: Coordinate | undefined,
+  setMouse: React.Dispatch<React.SetStateAction<Coordinate | undefined>>
 ) => {
   const [isPainting, setIsPainting] = useState<boolean>(false);
-  const [mousePosition, setMousePosition] = useState<Coordinate | undefined>(
-    undefined
-  );
 
   // canvas에 선긋는 함수
   const drawLine = (
@@ -37,115 +36,38 @@ export const usePen = (
     }
   };
 
-  const startPaint = useCallback(
-    (event: React.MouseEvent<HTMLCanvasElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
-      const coordinates: Coordinate = action(event);
-      if (coordinates) {
-        setIsPainting(true);
-        setMousePosition(coordinates);
-      }
-    },
-    []
-  );
+  const startPaint = useCallback((event: MouseEvent) => {
+    const coordinates = action(event);
+    if (coordinates) {
+      setIsPainting(true);
+      setMouse(coordinates);
+    }
+  }, []);
 
   const paint = useCallback(
-    (event: React.MouseEvent<HTMLCanvasElement>) => {
+    (event: MouseEvent) => {
       event.preventDefault();
       event.stopPropagation();
 
       if (isPainting) {
         const newMousePosition = action(event);
-        if (mousePosition && newMousePosition) {
-          drawLine(mousePosition, newMousePosition, color);
-          setMousePosition(newMousePosition);
+        if (mouse && newMousePosition) {
+          drawLine(mouse, newMousePosition, color);
+          setMouse(newMousePosition);
         }
       }
     },
-    [isPainting, mousePosition]
+    [isPainting, mouse]
   );
 
   const exitPaint = useCallback(() => {
     setIsPainting(false);
   }, []);
 
-  const startTouch = useCallback(
-    (event: React.TouchEvent<HTMLCanvasElement>) => {
-      event.preventDefault();
-      if (!ref.current) {
-        return;
-      }
-      const canvas: HTMLCanvasElement = ref.current;
-      if (event.touches.length === 0) {
-        return;
-      }
-      let touch = event.touches[0];
-      let mouseEvent = new MouseEvent("mousedown", {
-        clientX: touch.clientX,
-        clientY: touch.clientY,
-        button: 0,
-      });
-      canvas.dispatchEvent(mouseEvent);
-    },
-    []
-  );
-
-  const moveTouch = useCallback(
-    (event: React.TouchEvent<HTMLCanvasElement>) => {
-      event.preventDefault();
-      event.stopPropagation();
-
-      if (!ref.current) {
-        return;
-      }
-      const canvas: HTMLCanvasElement = ref.current;
-      if (event.touches.length === 0) {
-        return;
-      }
-      let touch = event.touches[0];
-      let mouseEvent = new MouseEvent("mousemove", {
-        clientX: touch.clientX,
-        clientY: touch.clientY,
-        button: 0,
-      });
-      canvas.dispatchEvent(mouseEvent);
-    },
-    []
-  );
-
-  const endTouch = useCallback((event: React.TouchEvent<HTMLCanvasElement>) => {
-    event.preventDefault();
-    event.stopPropagation();
-
-    if (!ref.current) {
-      return;
-    }
-    const canvas: HTMLCanvasElement = ref.current;
-    if (event.touches.length === 0) {
-      return;
-    }
-    let touch = event.touches[0];
-    let mouseUpEvent = new MouseEvent("mouseup", {
-      clientX: touch.clientX,
-      clientY: touch.clientY,
-      button: 0,
-    });
-    let mouseLeaveEvent = new MouseEvent("mouseleave", {
-      clientX: touch.clientX,
-      clientY: touch.clientY,
-      button: 0,
-    });
-    canvas.dispatchEvent(mouseUpEvent);
-    canvas.dispatchEvent(mouseLeaveEvent);
-  }, []);
-
   return {
     startPaint,
     paint,
     exitPaint,
-    endTouch,
-    startTouch,
-    moveTouch,
+    isPainting,
   };
 };

--- a/src/features/post/styles/DrawingStyle.ts
+++ b/src/features/post/styles/DrawingStyle.ts
@@ -93,6 +93,7 @@ export const EmoButton = styled.button<EmoButtonProps>`
 export const Canvas = styled.canvas<{ isCanvas: boolean }>`
   position: unset;
   background-color: ${themeColor.main.white};
+  touch-action: none;
   ${({ isCanvas }) =>
     !isCanvas &&
     css`


### PR DESCRIPTION
1. touch 이벤트를 mouse 이벤트로 dispatch 해주는 과정에서 react의 이벤트 핸들러인 onMouseDown, onMouseMove 등으로는 event dispatch가 어려운 것으로 판단되어 addEventListener, removeEventListener 사용을 통해 touch 이벤트를 mouse 이벤트로 dispatch해주는 데에 성공했습니다.
2. mouse, touch 이벤트를 처리해주는 로직이 canvas 컴포넌트 안에 있는것이 적합하다고 판단했고, 해당 이벤트 처리 함수를 usePen과 useEraser 에서 사용하고 있기 때문에 canvas 컴포넌트에 해당 이벤트 처리함수들을 넣게 되었습니다.
3. usePen과 useEraser가 같은 mousePosition 상태를 사용하고 있다고 판단되어, 이를 canvas 컴포넌트에서 선언해주고 props로 내려주게 되었습니다.
4. mousemove, touchmove와 같은 렌더링을 자주 일으키는 함수들에만 useCallback을 사용했습니다.